### PR TITLE
fix corner case where wrapToPi(pi) gave -pi instead of pi

### DIFF
--- a/navpy/core/navpy.py
+++ b/navpy/core/navpy.py
@@ -1206,6 +1206,6 @@ def wrapToPi(e):
     """
     dum,N = _input_check_Nx1(e)
     
-    ew = np.mod(e+np.pi,2*np.pi)-np.pi
+    ew = np.arctan2(np.sin(x), np.cos(x))
 
     return ew

--- a/navpy/core/navpy.py
+++ b/navpy/core/navpy.py
@@ -1206,6 +1206,6 @@ def wrapToPi(e):
     """
     dum,N = _input_check_Nx1(e)
     
-    ew = np.arctan2(np.sin(x), np.cos(x))
+    ew = np.arctan2(np.sin(e), np.cos(e))
 
     return ew


### PR DESCRIPTION
we're using NavPy at work, and I came across many cases where we use wrapToPi(pi) expecting to get pi, we get -pi instead.
I don't know if this is on purpose or no, I haven't found any related issues, but I made this pull request in any case.

Cheers.